### PR TITLE
add management of processes type enforcement mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,38 @@ selinux_port { 'udp/53':
 }
 ```
 
+Purge all network port type definitions that are not managed by puppet:
+```puppet
+resource { 'selinux_port':
+  purge => true,
+}
+```
+
+selinux_permissive_domain
+----------------
+
+Create or deletes the SELinux processes type enforcement mode.
+
+Example:
+
+Change apache to a permissive domain
+```puppet
+selinux_permissive_domain { 'httpd_t':
+  ensure => 'present',
+}
+```
+
+Remove apache from permissive domains
+```puppet
+selinux_permissive_domain { 'httpd_t':
+  ensure => 'absent',
+}
+```
+
+Purge all permissive domains that are not managed by puppet:
+Note: Rather not useful right now, as you can not currently remove permissive domains if they are the built-in into policy.
+```puppet
+resource { 'selinux_permissive_domain':
+  purge => true,
+}
+```

--- a/lib/puppet/provider/selinux_permissive_domain/semanage.rb
+++ b/lib/puppet/provider/selinux_permissive_domain/semanage.rb
@@ -1,0 +1,42 @@
+Puppet::Type.type(:selinux_permissive_domain).provide(:semanage) do
+  desc "Manage processes type enforcement mode"
+
+  commands :semanage => "semanage"
+
+  mk_resource_methods
+
+  def self.instances
+    domains = []
+    types = semanage('permissive', '-nl')
+    types.split("\n").collect do |t|
+      domains << new(
+        :name => t.strip,
+        :ensure => :present
+      )
+    end
+    domains 
+  end
+
+  def self.prefetch(resources)
+    domains = instances
+    resources.keys.each do |name|
+      if provider = domains.find{ |t| t.name == name}
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def create
+    semanage "permissive", "-a", resource[:name]
+    @property_hash[:ensure] = :present
+  end
+
+  def destroy
+    semanage "permissive", "-d", resource[:name]
+    @property_hash.clear
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+end

--- a/lib/puppet/type/selinux_permissive_domain.rb
+++ b/lib/puppet/type/selinux_permissive_domain.rb
@@ -1,0 +1,11 @@
+Puppet::Type.newtype(:selinux_permissive_domain) do
+  @doc = "Manage processes type enforcement mode"
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "Type to be changed to a permissive domain"
+    newvalues(/_t$/)
+  end
+
+end

--- a/tests/selinux_permissive_domain.pp
+++ b/tests/selinux_permissive_domain.pp
@@ -1,0 +1,14 @@
+# Make sure you have semanage command available
+# sudo puppet apply --noop --modulepath='..' tests/selinux_permissive_domain.pp
+
+selinux_permissive_domain {'httpd_t':
+  ensure => 'present',
+}
+
+selinux_permissive_domain {'condor_schedd_t':
+  ensure => 'absent'
+}
+
+resources {'selinux_permissive_domain':
+	purge => false,
+}

--- a/tests/selinux_port.pp
+++ b/tests/selinux_port.pp
@@ -1,4 +1,5 @@
-# puppet apply --noop --modulepath='..' tests/selinux_port.pp
+# Make sure you have semanage command available
+# sudo puppet apply --noop --modulepath='..' tests/selinux_port.pp
 
 selinux_port {'udp/53':
   seltype => 'dns_port_t'


### PR DESCRIPTION
Add ability to manage SELinux processes enforcement mode

``` puppet
selinux_permissive_domain {'httpd_t':
  ensure => 'present'
}
```

This is equivalent to `semange permissive -a httpd_t`
