### PR TITLE
changed the way semange is called so output can be captured

### DIFF
--- a/lib/puppet/provider/selinux_permissive_domain/semanage.rb
+++ b/lib/puppet/provider/selinux_permissive_domain/semanage.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:selinux_permissive_domain).provide(:semanage) do
 
   def self.instances
     domains = []
-    types = semanage('permissive', '-nl')
+    types = %x[#{command(:semanage)} permissive -nl]
     types.split("\n").collect do |t|
       domains << new(
         :name => t.strip,

--- a/lib/puppet/provider/selinux_port/semanage.rb
+++ b/lib/puppet/provider/selinux_port/semanage.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:selinux_port).provide(:semanage) do
 
   def self.instances
     types = []
-    out = semanage('port', '-nl')
+    out = %x[#{command(:semanage)} port -nl]
     out.split("\n").collect do |line|
       type, proto, ports = line.strip.squeeze(" ").split(" ",3)
       ports.gsub(/\s+/, "").split(',').each do |port|


### PR DESCRIPTION
We installed this type and it would apply the selinux port cleanly on the first run.  On following runs, the puppet type would cause an error while trying to reapply the same selinux port.  After much debugging, we found out that the way semanage was being called in this call:

out = semanage('port', '-nl')

out was never being populated.  Therefore, the exists? function always failed because there was nothing to check.  After making the changes, everything works as expected.

This was tested on RHEL 6.4 and puppet 2.7
