### PR TITLE
Fix NilClass on long paths

### DIFF
--- a/lib/puppet/provider/selinux_fcontext/semanage.rb
+++ b/lib/puppet/provider/selinux_fcontext/semanage.rb
@@ -30,7 +30,10 @@ Puppet::Type.type(:selinux_fcontext).provide(:semanage) do
     execpipe("#{command(:semanage)} fcontext -lC") do |out|
       lines = out.readlines[2..-1] || []
       lines.each do |line|
-        filespec, filetype, context = line.split(/\s\s+/)
+        args = line.split(/\s+/)
+        filespec = args[0]
+        filetype = args.length == 4 ? args[1..2].join(' ') : args[1]
+        context = args[-1]
         seluser, selrole, seltype, selrange = context.split(':')
         found[filespec] = { :ensure => :present, :filetype => filetype,
                             :selrange => selrange, :seltype => seltype,


### PR DESCRIPTION
When you have matching rules that are long the string matching fails.

```
/var/named/chroot/etc(/.*)?                        all files          system_u:object_r:etc_t:s0
/var/named/chroot/etc/named\.caching-nameserver\.conf regular file           system_u:object_r:named_conf_t:s0
/var/named/chroot/etc/named\.conf                  regular file       system_u:object_r:named_conf_t:s0
```

Here's a simple fix for that :). Filetypes don't exceed two words AFAIK.
