### PR TITLE
Fix fcontext provider for very long lines

### DIFF
--- a/lib/puppet/provider/selinux_fcontext/semanage.rb
+++ b/lib/puppet/provider/selinux_fcontext/semanage.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:selinux_fcontext).provide(:semanage) do
     execpipe("#{command(:semanage)} fcontext -lC") do |out|
       lines = out.readlines[2..-1] || []
       lines.each do |line|
-        filespec, filetype, context = line.scan(/^(\S+)\s+(\S+\s?\S+)\s+(\S+)$/).flatten
+        filespec, filetype, context = line.scan(/^(\S+)\s+(\S+\s?\S+)\s+(\S+)\s+$/).flatten
         seluser, selrole, seltype, selrange = context.split(':')
         found[filespec] = { :ensure => :present, :filetype => filetype,
                             :selrange => selrange, :seltype => seltype,


### PR DESCRIPTION
The regexp `\s\s+` for fcontext provider does not match very long lines where `filespec` is separated by just one white space.

The error we experienced is:
`Error: Could not prefetch selinux_fcontext provider 'semanage': undefined method`split' for nil:NilClass`

You can experiment a bit here:
http://rubular.com/r/DzLYBbuFMB

This is the new working regexp:
http://rubular.com/r/wOJKIYUwMh
